### PR TITLE
feat(blog): implement full blog module with Notion CMS and ebook reader

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,0 +1,62 @@
+import { notFound } from 'next/navigation';
+import type { Metadata } from 'next';
+import { getBlogPosts, getBlogPostBySlug, BlogReader } from '@/features/blog';
+
+// ISR: Revalidate every hour
+export const revalidate = 3600;
+
+// Generate static paths for all published posts
+export async function generateStaticParams() {
+  const posts = await getBlogPosts();
+  return posts.map((post) => ({ slug: post.slug }));
+}
+
+// Dynamic metadata for each post
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const post = await getBlogPostBySlug(slug);
+
+  if (!post) {
+    return { title: 'Post Not Found | Santiago Arias' };
+  }
+
+  return {
+    title: `${post.title} | Santiago Arias`,
+    description: post.excerpt,
+    openGraph: {
+      title: post.title,
+      description: post.excerpt,
+      type: 'article',
+      publishedTime: post.publishedDate,
+      authors: [post.author],
+      tags: post.tags,
+      ...(post.coverImage && {
+        images: [{ url: post.coverImage, alt: post.title }],
+      }),
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: post.title,
+      description: post.excerpt,
+    },
+  };
+}
+
+export default async function BlogPostPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const post = await getBlogPostBySlug(slug);
+
+  if (!post) {
+    notFound();
+  }
+
+  return <BlogReader post={post} />;
+}

--- a/app/blog/layout.tsx
+++ b/app/blog/layout.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Blog | Santiago Arias',
+  description:
+    'Thoughts on frontend development, AI integration, and software engineering best practices by Santiago Arias.',
+  openGraph: {
+    title: 'Blog | Santiago Arias',
+    description:
+      'Thoughts on frontend development, AI integration, and engineering leadership.',
+  },
+};
+
+export default function BlogLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,70 +1,44 @@
 import Link from 'next/link';
-import { ArrowLeft } from 'lucide-react';
+import { ArrowLeft, Rss } from 'lucide-react';
+import { getBlogPosts, BlogList } from '@/features/blog';
 
-// Shared imports (Clean Architecture)
-import { Card, CardContent, CardDescription, CardHeader, CardTitle, Badge, Button } from '@/shared';
+// ISR: Revalidate every hour
+export const revalidate = 3600;
 
-export default function BlogPage() {
-  const posts = [
-    {
-      title: "Improving LLM Context Usage with Smart Caching",
-      date: "2024-01-15",
-      category: "AI Engineering",
-      excerpt: "How we reduced token costs by 40% and improved response latency using a semantic caching layer for BitcoinIRA's AI features.",
-      slug: "llm-context-caching"
-    },
-    {
-      title: "The Planning, Coding, and Review Strategy",
-      date: "2023-11-20",
-      category: "Methodology",
-      excerpt: "A deep dive into the structured development workflow that eliminates 90% of bugs before they reach QA.",
-      slug: "planning-coding-review"
-    },
-    {
-      title: "Migrating to Next.js 16: A Guide",
-      date: "2024-02-01",
-      category: "Frontend",
-      excerpt: "Lessons learned from upgrading a large-scale application to the latest Next.js version, utilizing React 19 features.",
-      slug: "nextjs-16-migration"
-    }
-  ];
+export default async function BlogPage() {
+  const posts = await getBlogPosts();
 
   return (
     <div className="container py-20">
+      {/* Header */}
       <div className="mb-10">
-        <Link href="/">
-          <Button variant="ghost" className="pl-0 hover:pl-2 transition-all">
-            <ArrowLeft className="mr-2 h-4 w-4" />
-            Back to Home
-          </Button>
+        <Link
+          href="/"
+          className="mb-4 inline-flex items-center gap-2 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back to Home
         </Link>
-        <h1 className="text-4xl font-bold tracking-tight mt-4">Blog & Case Studies</h1>
-        <p className="text-muted-foreground mt-2 text-lg">
-          Thoughts on frontend development, AI integration, and software engineering best practices.
-        </p>
+
+        <div className="flex items-start justify-between">
+          <div>
+            <h1 className="text-4xl font-bold tracking-tight">
+              Blog & Case Studies
+            </h1>
+            <p className="mt-2 text-lg text-muted-foreground">
+              Thoughts on frontend development, AI integration, and software
+              engineering best practices.
+            </p>
+          </div>
+          <div className="hidden items-center gap-2 rounded-full border border-border px-3 py-1.5 text-xs text-muted-foreground sm:flex">
+            <Rss className="h-3 w-3" />
+            {posts.length} articles
+          </div>
+        </div>
       </div>
 
-      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-        {posts.map((post) => (
-          <Card key={post.slug} className="flex flex-col hover:border-primary/50 transition-colors cursor-pointer group">
-            <CardHeader>
-              <div className="flex justify-between items-start mb-2">
-                <Badge variant="outline">{post.category}</Badge>
-                <span className="text-sm text-muted-foreground">{post.date}</span>
-              </div>
-              <CardTitle className="group-hover:text-primary transition-colors">{post.title}</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <CardDescription className="line-clamp-3">
-                {post.excerpt}
-              </CardDescription>
-              <Button variant="link" className="px-0 mt-4 group-hover:underline">
-                Read more &rarr;
-              </Button>
-            </CardContent>
-          </Card>
-        ))}
-      </div>
+      {/* Posts */}
+      <BlogList posts={posts} />
     </div>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -87,3 +87,39 @@
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
 }
+
+/*
+   Blog Reader Theme Variables
+   Scoped to [data-reader-theme] for isolated theming
+*/
+[data-reader-theme="light"] {
+  --reader-bg: #ffffff;
+  --reader-fg: #1a1a1a;
+  --reader-muted: #6b6b6b;
+  --reader-border: #e5e5e5;
+  --reader-code-bg: #f5f5f5;
+}
+
+[data-reader-theme="dark"] {
+  --reader-bg: #141414;
+  --reader-fg: #e8e8e8;
+  --reader-muted: #888888;
+  --reader-border: #2a2a2a;
+  --reader-code-bg: #1e1e1e;
+}
+
+[data-reader-theme="sepia"] {
+  --reader-bg: #f4ecd8;
+  --reader-fg: #5b4636;
+  --reader-muted: #8b7355;
+  --reader-border: #d4c5a9;
+  --reader-code-bg: #ece4d0;
+}
+
+[data-reader-theme="paper"] {
+  --reader-bg: #faf9f6;
+  --reader-fg: #2d2d2d;
+  --reader-muted: #6b6b6b;
+  --reader-border: #e8e6e1;
+  --reader-code-bg: #f0efec;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,8 +4,11 @@ import { AIChat, AIWorkflow, AIExpertiseSection } from '@/features/ai';
 import { ExperienceSection } from '@/features/experience';
 import { EducationSection } from '@/features/education';
 import { GitHubActivity } from '@/features/github';
+import { getBlogPosts, BlogSection } from '@/features/blog';
 
-export default function Home() {
+export default async function Home() {
+  const posts = await getBlogPosts();
+
   return (
     <div className="flex flex-col min-h-screen">
       {/* Hero - First impression */}
@@ -22,6 +25,9 @@ export default function Home() {
 
       {/* AI Expertise - Detailed AI skills */}
       <AIExpertiseSection />
+
+      {/* Blog - Latest articles */}
+      <BlogSection posts={posts} />
 
       {/* Education */}
       <EducationSection />

--- a/features/blog/components/BlogCard.tsx
+++ b/features/blog/components/BlogCard.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import Link from 'next/link';
+import { motion } from 'framer-motion';
+import { Clock, ArrowRight } from 'lucide-react';
+import { formatDate } from '../lib/reading-utils';
+import type { BlogPost } from '../data/blog-types';
+
+interface BlogCardProps {
+  post: BlogPost;
+  index: number;
+}
+
+export function BlogCard({ post, index }: BlogCardProps) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 30 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.4, delay: index * 0.1, ease: 'easeOut' }}
+    >
+      <Link href={`/blog/${post.slug}`} className="group block h-full">
+        <article className="flex h-full flex-col rounded-xl border border-border/50 bg-card p-6 transition-all duration-300 hover:border-foreground/20 hover:shadow-lg hover:shadow-foreground/5">
+          {/* Cover image */}
+          {post.coverImage && (
+            <div className="mb-4 overflow-hidden rounded-lg">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={post.coverImage}
+                alt={post.title}
+                className="aspect-[16/9] w-full object-cover transition-transform duration-500 group-hover:scale-105"
+                loading="lazy"
+              />
+            </div>
+          )}
+
+          {/* Category + Date */}
+          <div className="mb-3 flex items-center gap-3">
+            <span className="rounded-full border border-border px-3 py-0.5 text-xs font-medium text-muted-foreground">
+              {post.category}
+            </span>
+            <span className="text-xs text-muted-foreground">
+              {formatDate(post.publishedDate)}
+            </span>
+          </div>
+
+          {/* Title */}
+          <h3 className="mb-2 text-lg font-semibold leading-snug tracking-tight transition-colors group-hover:text-foreground/80">
+            {post.title}
+          </h3>
+
+          {/* Excerpt */}
+          <p className="mb-4 flex-1 text-sm leading-relaxed text-muted-foreground line-clamp-3">
+            {post.excerpt}
+          </p>
+
+          {/* Footer */}
+          <div className="flex items-center justify-between text-xs text-muted-foreground">
+            <div className="flex items-center gap-3">
+              {post.readingTime && (
+                <span className="flex items-center gap-1">
+                  <Clock className="h-3 w-3" />
+                  {post.readingTime} min
+                </span>
+              )}
+            </div>
+            <span className="flex items-center gap-1 font-medium transition-all group-hover:gap-2">
+              Read <ArrowRight className="h-3 w-3" />
+            </span>
+          </div>
+        </article>
+      </Link>
+    </motion.div>
+  );
+}

--- a/features/blog/components/BlogList.tsx
+++ b/features/blog/components/BlogList.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import * as React from 'react';
+import { motion } from 'framer-motion';
+import { cn } from '@/shared/lib/utils';
+import { BlogCard } from './BlogCard';
+import type { BlogPost } from '../data/blog-types';
+
+export function BlogList({ posts }: { posts: BlogPost[] }) {
+  const categories = React.useMemo(() => {
+    const cats = new Set(posts.map((p) => p.category));
+    return ['All', ...Array.from(cats)];
+  }, [posts]);
+
+  const [activeCategory, setActiveCategory] = React.useState('All');
+
+  const filteredPosts = React.useMemo(() => {
+    if (activeCategory === 'All') return posts;
+    return posts.filter((p) => p.category === activeCategory);
+  }, [posts, activeCategory]);
+
+  return (
+    <div>
+      {/* Category filters */}
+      <motion.div
+        initial={{ opacity: 0, y: -10 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.3 }}
+        className="mb-8 flex flex-wrap gap-2"
+      >
+        {categories.map((cat) => (
+          <button
+            key={cat}
+            onClick={() => setActiveCategory(cat)}
+            className={cn(
+              'rounded-full border px-4 py-1.5 text-sm font-medium transition-all',
+              activeCategory === cat
+                ? 'border-foreground bg-foreground text-background'
+                : 'border-border text-muted-foreground hover:border-foreground/30 hover:text-foreground'
+            )}
+          >
+            {cat}
+          </button>
+        ))}
+      </motion.div>
+
+      {/* Posts grid */}
+      <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {filteredPosts.map((post, index) => (
+          <BlogCard key={post.id} post={post} index={index} />
+        ))}
+      </div>
+
+      {filteredPosts.length === 0 && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          className="py-20 text-center text-muted-foreground"
+        >
+          <p className="text-lg">No posts in this category yet.</p>
+        </motion.div>
+      )}
+    </div>
+  );
+}

--- a/features/blog/components/BlogReader.tsx
+++ b/features/blog/components/BlogReader.tsx
@@ -1,0 +1,186 @@
+'use client';
+
+import * as React from 'react';
+import Link from 'next/link';
+import { ArrowLeft, Clock, Calendar, Tag } from 'lucide-react';
+import { motion } from 'framer-motion';
+import { cn } from '@/shared/lib/utils';
+import { ReadingControls } from './ReadingControls';
+import { ReadingProgressBar } from './ReadingProgressBar';
+import { TableOfContents } from './TableOfContents';
+import { NotionBlockRenderer } from './NotionBlockRenderer';
+import { formatDate, extractHeadings } from '../lib/reading-utils';
+import {
+  FONT_OPTIONS,
+  WIDTH_OPTIONS,
+  DEFAULT_READING_PREFERENCES,
+  type ReadingPreferences,
+  type BlogPostWithContent,
+} from '../data/blog-types';
+
+const STORAGE_KEY = 'blog-reading-preferences';
+
+export function BlogReader({ post }: { post: BlogPostWithContent }) {
+  const [prefs, setPrefs] = React.useState<ReadingPreferences>(DEFAULT_READING_PREFERENCES);
+  const [mounted, setMounted] = React.useState(false);
+
+  // Load persisted preferences on mount
+  React.useEffect(() => {
+    try {
+      const saved = localStorage.getItem(STORAGE_KEY);
+      if (saved) setPrefs(JSON.parse(saved));
+    } catch { /* ignore */ }
+    setMounted(true);
+  }, []);
+
+  const updatePrefs = React.useCallback((updates: Partial<ReadingPreferences>) => {
+    setPrefs((prev) => {
+      const next = { ...prev, ...updates };
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+      } catch { /* ignore */ }
+      return next;
+    });
+  }, []);
+
+  const headings = React.useMemo(() => extractHeadings(post.blocks), [post.blocks]);
+
+  const fontFamily = FONT_OPTIONS.find((f) => f.value === prefs.fontFamily)?.family || FONT_OPTIONS[0].family;
+  const maxWidth = WIDTH_OPTIONS.find((w) => w.value === prefs.contentWidth)?.maxWidth || WIDTH_OPTIONS[1].maxWidth;
+
+  // Resolve the effective reader theme based on preferences
+  const readerTheme = prefs.theme;
+
+  return (
+    <>
+      <ReadingProgressBar />
+
+      <div
+        data-reader-theme={readerTheme}
+        className={cn(
+          'min-h-screen transition-colors duration-300',
+          'bg-[var(--reader-bg)] text-[var(--reader-fg)]'
+        )}
+        style={{ fontFamily, fontSize: `${prefs.fontSize}px`, lineHeight: prefs.lineHeight }}
+      >
+        {/* Header bar */}
+        <div className="border-b border-[var(--reader-border)] bg-[var(--reader-bg)]/80 backdrop-blur-sm">
+          <div className="container flex items-center justify-between py-3">
+            <Link
+              href="/blog"
+              className="flex items-center gap-2 text-sm font-medium text-[var(--reader-muted)] transition-colors hover:text-[var(--reader-fg)]"
+            >
+              <ArrowLeft className="h-4 w-4" />
+              Back to Blog
+            </Link>
+            {mounted && (
+              <ReadingControls preferences={prefs} onUpdate={updatePrefs} />
+            )}
+          </div>
+        </div>
+
+        {/* Article layout */}
+        <div className="container py-8">
+          <div className="flex gap-12">
+            {/* Main content */}
+            <motion.article
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5 }}
+              className="mx-auto w-full"
+              style={{ maxWidth }}
+            >
+              {/* Post header */}
+              <header className="mb-10">
+                {post.coverImage && (
+                  <div className="mb-8 overflow-hidden rounded-xl border border-[var(--reader-border)]">
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src={post.coverImage}
+                      alt={post.title}
+                      className="w-full object-cover"
+                      style={{ maxHeight: '400px' }}
+                    />
+                  </div>
+                )}
+
+                <div className="mb-4 flex flex-wrap items-center gap-3 text-sm text-[var(--reader-muted)]">
+                  {post.category && (
+                    <span className="rounded-full border border-[var(--reader-border)] px-3 py-1 font-medium">
+                      {post.category}
+                    </span>
+                  )}
+                  <span className="flex items-center gap-1">
+                    <Calendar className="h-3.5 w-3.5" />
+                    {formatDate(post.publishedDate)}
+                  </span>
+                  {post.readingTime && (
+                    <span className="flex items-center gap-1">
+                      <Clock className="h-3.5 w-3.5" />
+                      {post.readingTime} min read
+                    </span>
+                  )}
+                </div>
+
+                <h1 className="mb-4 text-[2em] font-bold leading-tight tracking-tight">
+                  {post.title}
+                </h1>
+
+                <p className="text-lg text-[var(--reader-muted)]">
+                  {post.excerpt}
+                </p>
+
+                {post.tags.length > 0 && (
+                  <div className="mt-4 flex flex-wrap gap-2">
+                    {post.tags.map((tag) => (
+                      <span
+                        key={tag}
+                        className="flex items-center gap-1 rounded-md bg-[var(--reader-code-bg)] px-2 py-1 text-xs text-[var(--reader-muted)]"
+                      >
+                        <Tag className="h-3 w-3" />
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+                )}
+
+                <hr className="mt-8 border-[var(--reader-border)]" />
+              </header>
+
+              {/* Table of Contents (mobile) */}
+              <div className="mb-8">
+                <TableOfContents headings={headings} />
+              </div>
+
+              {/* Post content */}
+              <div className="blog-content">
+                <NotionBlockRenderer blocks={post.blocks} />
+              </div>
+
+              {/* Footer */}
+              <footer className="mt-16 border-t border-[var(--reader-border)] pt-8">
+                <div className="flex items-center justify-between">
+                  <div className="text-sm text-[var(--reader-muted)]">
+                    Written by <span className="font-medium text-[var(--reader-fg)]">{post.author}</span>
+                  </div>
+                  <Link
+                    href="/blog"
+                    className="flex items-center gap-2 text-sm font-medium text-[var(--reader-muted)] transition-colors hover:text-[var(--reader-fg)]"
+                  >
+                    <ArrowLeft className="h-4 w-4" />
+                    More articles
+                  </Link>
+                </div>
+              </footer>
+            </motion.article>
+
+            {/* Desktop TOC sidebar */}
+            <div className="hidden xl:block xl:w-64 xl:shrink-0">
+              <TableOfContents headings={headings} />
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/features/blog/components/BlogSection.tsx
+++ b/features/blog/components/BlogSection.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import Link from 'next/link';
+import { motion } from 'framer-motion';
+import { ArrowRight, BookOpen } from 'lucide-react';
+import { BlogCard } from './BlogCard';
+import type { BlogPost } from '../data/blog-types';
+
+export function BlogSection({ posts }: { posts: BlogPost[] }) {
+  const latestPosts = posts.slice(0, 3);
+
+  return (
+    <section id="blog" className="border-t border-border/40 py-20">
+      <div className="container">
+        {/* Section header */}
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true, margin: '-100px' }}
+          transition={{ duration: 0.5 }}
+          className="mb-12 flex items-end justify-between"
+        >
+          <div>
+            <div className="mb-3 flex items-center gap-2 text-sm font-medium text-muted-foreground">
+              <BookOpen className="h-4 w-4" />
+              Blog & Case Studies
+            </div>
+            <h2 className="text-3xl font-bold tracking-tight">
+              Latest Articles
+            </h2>
+            <p className="mt-2 text-muted-foreground">
+              Thoughts on frontend development, AI integration, and engineering leadership.
+            </p>
+          </div>
+          <Link
+            href="/blog"
+            className="hidden items-center gap-2 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground sm:flex"
+          >
+            View all
+            <ArrowRight className="h-4 w-4" />
+          </Link>
+        </motion.div>
+
+        {/* Posts grid */}
+        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {latestPosts.map((post, index) => (
+            <BlogCard key={post.id} post={post} index={index} />
+          ))}
+        </div>
+
+        {/* Mobile: View all link */}
+        <motion.div
+          initial={{ opacity: 0 }}
+          whileInView={{ opacity: 1 }}
+          viewport={{ once: true }}
+          className="mt-8 text-center sm:hidden"
+        >
+          <Link
+            href="/blog"
+            className="inline-flex items-center gap-2 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+          >
+            View all articles
+            <ArrowRight className="h-4 w-4" />
+          </Link>
+        </motion.div>
+      </div>
+    </section>
+  );
+}

--- a/features/blog/components/NotionBlockRenderer.tsx
+++ b/features/blog/components/NotionBlockRenderer.tsx
@@ -1,0 +1,349 @@
+// Blog Feature - Notion Block Renderer
+// Converts Notion API blocks to styled JSX for the ebook reader
+
+import type { NotionBlock, NotionRichText } from '../data/blog-types';
+
+function RichText({ richText }: { richText: NotionRichText[] }) {
+  if (!richText?.length) return null;
+
+  return (
+    <>
+      {richText.map((text, i) => {
+        let element: React.ReactNode = text.plain_text;
+        const { annotations } = text;
+
+        if (annotations?.code) {
+          element = (
+            <code className="rounded bg-[var(--reader-code-bg)] px-1.5 py-0.5 font-mono text-[0.875em]">
+              {element}
+            </code>
+          );
+        }
+        if (annotations?.bold) element = <strong>{element}</strong>;
+        if (annotations?.italic) element = <em>{element}</em>;
+        if (annotations?.strikethrough) element = <s>{element}</s>;
+        if (annotations?.underline) element = <u>{element}</u>;
+
+        if (text.href) {
+          element = (
+            <a
+              href={text.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline decoration-[var(--reader-muted)] underline-offset-2 transition-colors hover:decoration-[var(--reader-fg)]"
+            >
+              {element}
+            </a>
+          );
+        }
+
+        return <span key={i}>{element}</span>;
+      })}
+    </>
+  );
+}
+
+function BlockRenderer({ block }: { block: NotionBlock }) {
+  const content = block[block.type];
+
+  switch (block.type) {
+    case 'paragraph':
+      if (!content?.rich_text?.length) return <div className="h-4" />;
+      return (
+        <p className="mb-6 leading-[inherit]">
+          <RichText richText={content.rich_text} />
+        </p>
+      );
+
+    case 'heading_1':
+      return (
+        <h2
+          id={block.id}
+          className="mb-4 mt-12 scroll-mt-24 text-[1.75em] font-bold tracking-tight first:mt-0"
+        >
+          <RichText richText={content.rich_text} />
+        </h2>
+      );
+
+    case 'heading_2':
+      return (
+        <h3
+          id={block.id}
+          className="mb-3 mt-10 scroll-mt-24 text-[1.375em] font-semibold tracking-tight first:mt-0"
+        >
+          <RichText richText={content.rich_text} />
+        </h3>
+      );
+
+    case 'heading_3':
+      return (
+        <h4
+          id={block.id}
+          className="mb-2 mt-8 scroll-mt-24 text-[1.125em] font-semibold first:mt-0"
+        >
+          <RichText richText={content.rich_text} />
+        </h4>
+      );
+
+    case 'bulleted_list_item':
+      return (
+        <li className="mb-2 ml-6 list-disc leading-[inherit]">
+          <RichText richText={content.rich_text} />
+          {block.children && (
+            <ul className="mt-2">
+              {block.children.map((child) => (
+                <BlockRenderer key={child.id} block={child} />
+              ))}
+            </ul>
+          )}
+        </li>
+      );
+
+    case 'numbered_list_item':
+      return (
+        <li className="mb-2 ml-6 list-decimal leading-[inherit]">
+          <RichText richText={content.rich_text} />
+          {block.children && (
+            <ol className="mt-2">
+              {block.children.map((child) => (
+                <BlockRenderer key={child.id} block={child} />
+              ))}
+            </ol>
+          )}
+        </li>
+      );
+
+    case 'to_do':
+      return (
+        <div className="mb-2 flex items-start gap-3">
+          <div
+            className={`mt-1 flex h-5 w-5 shrink-0 items-center justify-center rounded border-2 transition-colors ${
+              content.checked
+                ? 'border-[var(--reader-fg)] bg-[var(--reader-fg)]'
+                : 'border-[var(--reader-muted)]'
+            }`}
+          >
+            {content.checked && (
+              <svg className="h-3 w-3 text-[var(--reader-bg)]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+              </svg>
+            )}
+          </div>
+          <span className={content.checked ? 'line-through opacity-60' : ''}>
+            <RichText richText={content.rich_text} />
+          </span>
+        </div>
+      );
+
+    case 'code': {
+      const language = content.language || '';
+      const codeText = content.rich_text?.map((t: NotionRichText) => t.plain_text).join('') || '';
+      return (
+        <div className="group relative my-6">
+          {language && (
+            <div className="absolute right-3 top-3 rounded bg-[var(--reader-muted)]/20 px-2 py-0.5 font-mono text-xs text-[var(--reader-muted)]">
+              {language}
+            </div>
+          )}
+          <pre className="overflow-x-auto rounded-lg border border-[var(--reader-border)] bg-[var(--reader-code-bg)] p-4 font-mono text-[0.875em] leading-relaxed">
+            <code>{codeText}</code>
+          </pre>
+          {content.caption?.length > 0 && (
+            <p className="mt-2 text-center text-sm text-[var(--reader-muted)]">
+              <RichText richText={content.caption} />
+            </p>
+          )}
+        </div>
+      );
+    }
+
+    case 'image': {
+      const src =
+        content.type === 'external'
+          ? content.external?.url
+          : content.file?.url;
+      if (!src) return null;
+      const caption = content.caption?.[0]?.plain_text || '';
+      return (
+        <figure className="my-8">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={src}
+            alt={caption}
+            className="w-full rounded-lg border border-[var(--reader-border)]"
+            loading="lazy"
+          />
+          {caption && (
+            <figcaption className="mt-3 text-center text-sm text-[var(--reader-muted)]">
+              {caption}
+            </figcaption>
+          )}
+        </figure>
+      );
+    }
+
+    case 'divider':
+      return (
+        <hr className="my-10 border-t border-[var(--reader-border)]" />
+      );
+
+    case 'quote':
+      return (
+        <blockquote className="my-6 border-l-4 border-[var(--reader-fg)] pl-6 italic opacity-90">
+          <RichText richText={content.rich_text} />
+        </blockquote>
+      );
+
+    case 'callout': {
+      const emoji = content.icon?.emoji || '';
+      return (
+        <div className="my-6 flex gap-4 rounded-lg border border-[var(--reader-border)] bg-[var(--reader-code-bg)] p-5">
+          {emoji && <span className="shrink-0 text-xl">{emoji}</span>}
+          <div className="leading-[inherit]">
+            <RichText richText={content.rich_text} />
+          </div>
+        </div>
+      );
+    }
+
+    case 'bookmark':
+      return (
+        <a
+          href={content.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="my-4 block rounded-lg border border-[var(--reader-border)] p-4 transition-colors hover:bg-[var(--reader-code-bg)]"
+        >
+          <span className="text-sm text-[var(--reader-muted)]">{content.url}</span>
+          {content.caption?.length > 0 && (
+            <p className="mt-1 text-sm">
+              <RichText richText={content.caption} />
+            </p>
+          )}
+        </a>
+      );
+
+    case 'toggle':
+      return (
+        <details className="my-4 rounded-lg border border-[var(--reader-border)] p-4">
+          <summary className="cursor-pointer font-medium">
+            <RichText richText={content.rich_text} />
+          </summary>
+          {block.children && (
+            <div className="mt-3 pl-4">
+              {block.children.map((child) => (
+                <BlockRenderer key={child.id} block={child} />
+              ))}
+            </div>
+          )}
+        </details>
+      );
+
+    case 'table':
+      return (
+        <div className="my-6 overflow-x-auto">
+          <table className="w-full border-collapse rounded-lg border border-[var(--reader-border)]">
+            <tbody>
+              {block.children?.map((row, rowIndex) => (
+                <tr key={row.id} className={rowIndex === 0 && content.has_column_header ? 'font-semibold' : ''}>
+                  {row.table_row?.cells?.map((cell: NotionRichText[], cellIndex: number) => {
+                    const Tag = (rowIndex === 0 && content.has_column_header) || (cellIndex === 0 && content.has_row_header) ? 'th' : 'td';
+                    return (
+                      <Tag
+                        key={cellIndex}
+                        className="border border-[var(--reader-border)] p-3 text-left"
+                      >
+                        <RichText richText={cell} />
+                      </Tag>
+                    );
+                  })}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      );
+
+    case 'embed':
+    case 'video': {
+      const url = content.type === 'external' ? content.external?.url : content.url;
+      if (!url) return null;
+      return (
+        <div className="my-6 aspect-video overflow-hidden rounded-lg border border-[var(--reader-border)]">
+          <iframe
+            src={url}
+            className="h-full w-full"
+            allowFullScreen
+            loading="lazy"
+            title="Embedded content"
+          />
+        </div>
+      );
+    }
+
+    default:
+      return null;
+  }
+}
+
+/**
+ * Groups consecutive list items into proper <ul> / <ol> wrappers
+ */
+function groupBlocks(blocks: NotionBlock[]): React.ReactNode[] {
+  const result: React.ReactNode[] = [];
+  let i = 0;
+
+  while (i < blocks.length) {
+    const block = blocks[i];
+
+    if (block.type === 'bulleted_list_item') {
+      const items: NotionBlock[] = [];
+      while (i < blocks.length && blocks[i].type === 'bulleted_list_item') {
+        items.push(blocks[i]);
+        i++;
+      }
+      result.push(
+        <ul key={items[0].id} className="my-4">
+          {items.map((item) => (
+            <BlockRenderer key={item.id} block={item} />
+          ))}
+        </ul>
+      );
+    } else if (block.type === 'numbered_list_item') {
+      const items: NotionBlock[] = [];
+      while (i < blocks.length && blocks[i].type === 'numbered_list_item') {
+        items.push(blocks[i]);
+        i++;
+      }
+      result.push(
+        <ol key={items[0].id} className="my-4">
+          {items.map((item) => (
+            <BlockRenderer key={item.id} block={item} />
+          ))}
+        </ol>
+      );
+    } else if (block.type === 'to_do') {
+      const items: NotionBlock[] = [];
+      while (i < blocks.length && blocks[i].type === 'to_do') {
+        items.push(blocks[i]);
+        i++;
+      }
+      result.push(
+        <div key={items[0].id} className="my-4">
+          {items.map((item) => (
+            <BlockRenderer key={item.id} block={item} />
+          ))}
+        </div>
+      );
+    } else {
+      result.push(<BlockRenderer key={block.id} block={block} />);
+      i++;
+    }
+  }
+
+  return result;
+}
+
+export function NotionBlockRenderer({ blocks }: { blocks: NotionBlock[] }) {
+  return <>{groupBlocks(blocks)}</>;
+}

--- a/features/blog/components/ReadingControls.tsx
+++ b/features/blog/components/ReadingControls.tsx
@@ -1,0 +1,231 @@
+'use client';
+
+import * as React from 'react';
+import { Settings, Type, Minus, Plus, X } from 'lucide-react';
+import { cn } from '@/shared/lib/utils';
+import {
+  FONT_OPTIONS,
+  WIDTH_OPTIONS,
+  THEME_OPTIONS,
+  DEFAULT_READING_PREFERENCES,
+  type ReadingPreferences,
+} from '../data/blog-types';
+
+interface ReadingControlsProps {
+  preferences: ReadingPreferences;
+  onUpdate: (updates: Partial<ReadingPreferences>) => void;
+}
+
+export function ReadingControls({ preferences, onUpdate }: ReadingControlsProps) {
+  const [isOpen, setIsOpen] = React.useState(false);
+
+  const handleReset = () => {
+    onUpdate(DEFAULT_READING_PREFERENCES);
+  };
+
+  return (
+    <div className="relative">
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className={cn(
+          'flex items-center gap-2 rounded-lg border px-3 py-2 text-sm font-medium transition-all',
+          isOpen
+            ? 'border-[var(--reader-fg)] bg-[var(--reader-fg)] text-[var(--reader-bg)]'
+            : 'border-[var(--reader-border)] bg-[var(--reader-code-bg)] text-[var(--reader-fg)] hover:border-[var(--reader-fg)]/50'
+        )}
+        aria-label="Reading settings"
+      >
+        <Settings className="h-4 w-4" />
+        <Type className="h-4 w-4" />
+      </button>
+
+      {isOpen && (
+        <>
+          {/* Backdrop */}
+          <div
+            className="fixed inset-0 z-40"
+            onClick={() => setIsOpen(false)}
+          />
+
+          {/* Panel */}
+          <div className="absolute right-0 top-full z-50 mt-2 w-80 animate-in fade-in slide-in-from-top-2 rounded-xl border border-[var(--reader-border)] bg-[var(--reader-bg)] p-5 shadow-xl">
+            <div className="mb-4 flex items-center justify-between">
+              <h3 className="font-semibold text-[var(--reader-fg)]">
+                Reading Settings
+              </h3>
+              <button
+                onClick={() => setIsOpen(false)}
+                className="rounded-md p-1 text-[var(--reader-muted)] hover:text-[var(--reader-fg)]"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+
+            {/* Theme */}
+            <div className="mb-5">
+              <label className="mb-2 block text-xs font-medium uppercase tracking-wider text-[var(--reader-muted)]">
+                Theme
+              </label>
+              <div className="grid grid-cols-4 gap-2">
+                {THEME_OPTIONS.map((theme) => (
+                  <button
+                    key={theme.value}
+                    onClick={() => onUpdate({ theme: theme.value })}
+                    className={cn(
+                      'flex flex-col items-center gap-1 rounded-lg border-2 p-2 text-xs transition-all',
+                      preferences.theme === theme.value
+                        ? 'border-[var(--reader-fg)] bg-[var(--reader-fg)]/10'
+                        : 'border-transparent hover:border-[var(--reader-border)]'
+                    )}
+                  >
+                    <span className="text-lg">{theme.icon}</span>
+                    <span>{theme.label}</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Font Family */}
+            <div className="mb-5">
+              <label className="mb-2 block text-xs font-medium uppercase tracking-wider text-[var(--reader-muted)]">
+                Font
+              </label>
+              <div className="grid grid-cols-2 gap-2">
+                {FONT_OPTIONS.map((font) => (
+                  <button
+                    key={font.value}
+                    onClick={() => onUpdate({ fontFamily: font.value })}
+                    className={cn(
+                      'rounded-lg border-2 px-3 py-2 text-sm transition-all',
+                      preferences.fontFamily === font.value
+                        ? 'border-[var(--reader-fg)] bg-[var(--reader-fg)]/10 font-medium'
+                        : 'border-transparent hover:border-[var(--reader-border)]'
+                    )}
+                    style={{ fontFamily: font.family }}
+                  >
+                    {font.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Font Size */}
+            <div className="mb-5">
+              <div className="mb-2 flex items-center justify-between">
+                <label className="text-xs font-medium uppercase tracking-wider text-[var(--reader-muted)]">
+                  Size
+                </label>
+                <span className="text-xs text-[var(--reader-muted)]">
+                  {preferences.fontSize}px
+                </span>
+              </div>
+              <div className="flex items-center gap-3">
+                <button
+                  onClick={() =>
+                    onUpdate({ fontSize: Math.max(14, preferences.fontSize - 1) })
+                  }
+                  className="rounded-md border border-[var(--reader-border)] p-1.5 hover:bg-[var(--reader-code-bg)]"
+                >
+                  <Minus className="h-3 w-3" />
+                </button>
+                <input
+                  type="range"
+                  min={14}
+                  max={24}
+                  value={preferences.fontSize}
+                  onChange={(e) =>
+                    onUpdate({ fontSize: parseInt(e.target.value) })
+                  }
+                  className="h-1.5 flex-1 cursor-pointer appearance-none rounded-full bg-[var(--reader-border)] accent-[var(--reader-fg)] [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-[var(--reader-fg)]"
+                />
+                <button
+                  onClick={() =>
+                    onUpdate({ fontSize: Math.min(24, preferences.fontSize + 1) })
+                  }
+                  className="rounded-md border border-[var(--reader-border)] p-1.5 hover:bg-[var(--reader-code-bg)]"
+                >
+                  <Plus className="h-3 w-3" />
+                </button>
+              </div>
+            </div>
+
+            {/* Line Height */}
+            <div className="mb-5">
+              <div className="mb-2 flex items-center justify-between">
+                <label className="text-xs font-medium uppercase tracking-wider text-[var(--reader-muted)]">
+                  Line Spacing
+                </label>
+                <span className="text-xs text-[var(--reader-muted)]">
+                  {preferences.lineHeight.toFixed(1)}
+                </span>
+              </div>
+              <div className="flex items-center gap-3">
+                <button
+                  onClick={() =>
+                    onUpdate({
+                      lineHeight: Math.max(1.4, +(preferences.lineHeight - 0.1).toFixed(1)),
+                    })
+                  }
+                  className="rounded-md border border-[var(--reader-border)] p-1.5 hover:bg-[var(--reader-code-bg)]"
+                >
+                  <Minus className="h-3 w-3" />
+                </button>
+                <input
+                  type="range"
+                  min={14}
+                  max={22}
+                  value={preferences.lineHeight * 10}
+                  onChange={(e) =>
+                    onUpdate({ lineHeight: parseInt(e.target.value) / 10 })
+                  }
+                  className="h-1.5 flex-1 cursor-pointer appearance-none rounded-full bg-[var(--reader-border)] accent-[var(--reader-fg)] [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-[var(--reader-fg)]"
+                />
+                <button
+                  onClick={() =>
+                    onUpdate({
+                      lineHeight: Math.min(2.2, +(preferences.lineHeight + 0.1).toFixed(1)),
+                    })
+                  }
+                  className="rounded-md border border-[var(--reader-border)] p-1.5 hover:bg-[var(--reader-code-bg)]"
+                >
+                  <Plus className="h-3 w-3" />
+                </button>
+              </div>
+            </div>
+
+            {/* Content Width */}
+            <div className="mb-4">
+              <label className="mb-2 block text-xs font-medium uppercase tracking-wider text-[var(--reader-muted)]">
+                Width
+              </label>
+              <div className="grid grid-cols-3 gap-2">
+                {WIDTH_OPTIONS.map((width) => (
+                  <button
+                    key={width.value}
+                    onClick={() => onUpdate({ contentWidth: width.value })}
+                    className={cn(
+                      'rounded-lg border-2 px-3 py-1.5 text-xs font-medium transition-all',
+                      preferences.contentWidth === width.value
+                        ? 'border-[var(--reader-fg)] bg-[var(--reader-fg)]/10'
+                        : 'border-transparent hover:border-[var(--reader-border)]'
+                    )}
+                  >
+                    {width.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Reset */}
+            <button
+              onClick={handleReset}
+              className="w-full rounded-lg border border-[var(--reader-border)] py-2 text-xs font-medium text-[var(--reader-muted)] transition-colors hover:bg-[var(--reader-code-bg)] hover:text-[var(--reader-fg)]"
+            >
+              Reset to defaults
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/features/blog/components/ReadingProgressBar.tsx
+++ b/features/blog/components/ReadingProgressBar.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import * as React from 'react';
+
+export function ReadingProgressBar() {
+  const [progress, setProgress] = React.useState(0);
+
+  React.useEffect(() => {
+    function handleScroll() {
+      const scrollTop = window.scrollY;
+      const docHeight = document.documentElement.scrollHeight - window.innerHeight;
+      if (docHeight > 0) {
+        setProgress(Math.min((scrollTop / docHeight) * 100, 100));
+      }
+    }
+
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    handleScroll();
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
+
+  return (
+    <div className="fixed left-0 top-0 z-[60] h-[3px] w-full">
+      <div
+        className="h-full bg-gradient-to-r from-foreground/60 via-foreground to-foreground/60 transition-[width] duration-150 ease-out"
+        style={{ width: `${progress}%` }}
+      />
+    </div>
+  );
+}

--- a/features/blog/components/TableOfContents.tsx
+++ b/features/blog/components/TableOfContents.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import * as React from 'react';
+import { List, ChevronDown } from 'lucide-react';
+import { cn } from '@/shared/lib/utils';
+
+interface Heading {
+  id: string;
+  text: string;
+  level: number;
+}
+
+export function TableOfContents({ headings }: { headings: Heading[] }) {
+  const [activeId, setActiveId] = React.useState('');
+  const [isOpen, setIsOpen] = React.useState(false);
+
+  React.useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            setActiveId(entry.target.id);
+          }
+        }
+      },
+      { rootMargin: '-80px 0px -70% 0px', threshold: 0 }
+    );
+
+    for (const heading of headings) {
+      const el = document.getElementById(heading.id);
+      if (el) observer.observe(el);
+    }
+
+    return () => observer.disconnect();
+  }, [headings]);
+
+  const handleClick = (id: string) => {
+    const el = document.getElementById(id);
+    if (el) {
+      el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      setIsOpen(false);
+    }
+  };
+
+  if (headings.length < 2) return null;
+
+  return (
+    <>
+      {/* Desktop: Sidebar */}
+      <nav className="hidden xl:block" aria-label="Table of contents">
+        <div className="sticky top-24">
+          <h4 className="mb-4 text-xs font-semibold uppercase tracking-wider text-[var(--reader-muted)]">
+            On this page
+          </h4>
+          <ul className="space-y-2">
+            {headings.map((heading) => (
+              <li key={heading.id}>
+                <button
+                  onClick={() => handleClick(heading.id)}
+                  className={cn(
+                    'block w-full text-left text-sm leading-snug transition-all duration-200',
+                    heading.level === 2 && 'pl-0',
+                    heading.level === 3 && 'pl-4',
+                    activeId === heading.id
+                      ? 'font-medium text-[var(--reader-fg)]'
+                      : 'text-[var(--reader-muted)] hover:text-[var(--reader-fg)]'
+                  )}
+                >
+                  {heading.text}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </nav>
+
+      {/* Mobile: Collapsible */}
+      <div className="xl:hidden">
+        <button
+          onClick={() => setIsOpen(!isOpen)}
+          className="flex w-full items-center gap-2 rounded-lg border border-[var(--reader-border)] bg-[var(--reader-code-bg)] px-4 py-3 text-sm font-medium transition-colors"
+        >
+          <List className="h-4 w-4" />
+          <span>Table of Contents</span>
+          <ChevronDown
+            className={cn(
+              'ml-auto h-4 w-4 transition-transform duration-200',
+              isOpen && 'rotate-180'
+            )}
+          />
+        </button>
+        {isOpen && (
+          <ul className="mt-2 space-y-1 rounded-lg border border-[var(--reader-border)] bg-[var(--reader-code-bg)] p-3">
+            {headings.map((heading) => (
+              <li key={heading.id}>
+                <button
+                  onClick={() => handleClick(heading.id)}
+                  className={cn(
+                    'block w-full rounded px-3 py-1.5 text-left text-sm transition-colors',
+                    heading.level === 3 && 'pl-7',
+                    activeId === heading.id
+                      ? 'bg-[var(--reader-fg)]/10 font-medium text-[var(--reader-fg)]'
+                      : 'text-[var(--reader-muted)] hover:text-[var(--reader-fg)]'
+                  )}
+                >
+                  {heading.text}
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </>
+  );
+}

--- a/features/blog/data/blog-types.ts
+++ b/features/blog/data/blog-types.ts
@@ -1,0 +1,453 @@
+// Blog Feature - Types & Constants
+
+export interface BlogPost {
+  id: string;
+  slug: string;
+  title: string;
+  excerpt: string;
+  category: string;
+  tags: string[];
+  coverImage: string | null;
+  publishedDate: string;
+  author: string;
+  readingTime?: number;
+}
+
+export interface BlogPostWithContent extends BlogPost {
+  blocks: NotionBlock[];
+}
+
+export interface NotionRichText {
+  type: string;
+  text?: { content: string; link: { url: string } | null };
+  annotations: {
+    bold: boolean;
+    italic: boolean;
+    strikethrough: boolean;
+    underline: boolean;
+    code: boolean;
+    color: string;
+  };
+  plain_text: string;
+  href: string | null;
+}
+
+export interface NotionBlock {
+  id: string;
+  type: string;
+  has_children: boolean;
+  children?: NotionBlock[];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any;
+}
+
+export interface ReadingPreferences {
+  fontFamily: 'georgia' | 'system-sans' | 'mono' | 'charter';
+  fontSize: number;
+  lineHeight: number;
+  contentWidth: 'narrow' | 'medium' | 'wide';
+  theme: 'light' | 'dark' | 'sepia' | 'paper';
+}
+
+export const DEFAULT_READING_PREFERENCES: ReadingPreferences = {
+  fontFamily: 'georgia',
+  fontSize: 18,
+  lineHeight: 1.8,
+  contentWidth: 'medium',
+  theme: 'light',
+};
+
+export const FONT_OPTIONS = [
+  { value: 'georgia' as const, label: 'Georgia', family: "Georgia, 'Times New Roman', serif" },
+  { value: 'system-sans' as const, label: 'Sans Serif', family: 'var(--font-sans), system-ui, sans-serif' },
+  { value: 'charter' as const, label: 'Charter', family: "Charter, 'Bitstream Charter', Georgia, serif" },
+  { value: 'mono' as const, label: 'Monospace', family: 'var(--font-mono), monospace' },
+] as const;
+
+export const WIDTH_OPTIONS = [
+  { value: 'narrow' as const, label: 'Narrow', maxWidth: '580px' },
+  { value: 'medium' as const, label: 'Medium', maxWidth: '720px' },
+  { value: 'wide' as const, label: 'Wide', maxWidth: '900px' },
+] as const;
+
+export const THEME_OPTIONS = [
+  { value: 'light' as const, label: 'Light', icon: '☀️' },
+  { value: 'dark' as const, label: 'Dark', icon: '🌙' },
+  { value: 'sepia' as const, label: 'Sepia', icon: '📜' },
+  { value: 'paper' as const, label: 'Paper', icon: '📄' },
+] as const;
+
+// Sample posts for when Notion is not configured
+export const SAMPLE_POSTS: BlogPost[] = [
+  {
+    id: 'sample-1',
+    slug: 'building-ai-first-development-workflow',
+    title: 'Building an AI-First Development Workflow',
+    excerpt: 'How I transformed my development process by integrating AI tools at every stage — from planning and architecture to code review and deployment.',
+    category: 'AI Engineering',
+    tags: ['AI', 'Developer Tools', 'Productivity', 'Claude'],
+    coverImage: null,
+    publishedDate: '2026-02-10',
+    author: 'Santiago Arias',
+    readingTime: 8,
+  },
+  {
+    id: 'sample-2',
+    slug: 'llm-context-caching-strategy',
+    title: 'Improving LLM Context Usage with Smart Caching',
+    excerpt: 'How we reduced token costs by 40% and improved response latency using a semantic caching layer for production AI features.',
+    category: 'AI Engineering',
+    tags: ['LLM', 'Caching', 'Performance', 'Architecture'],
+    coverImage: null,
+    publishedDate: '2026-01-15',
+    author: 'Santiago Arias',
+    readingTime: 6,
+  },
+  {
+    id: 'sample-3',
+    slug: 'nextjs-16-migration-guide',
+    title: 'Migrating to Next.js 16: Lessons from Production',
+    excerpt: 'A practical guide to upgrading a large-scale application to Next.js 16 with React 19, covering the pitfalls and performance wins.',
+    category: 'Frontend',
+    tags: ['Next.js', 'React 19', 'Migration', 'Performance'],
+    coverImage: null,
+    publishedDate: '2026-01-02',
+    author: 'Santiago Arias',
+    readingTime: 10,
+  },
+  {
+    id: 'sample-4',
+    slug: 'planning-coding-review-strategy',
+    title: 'The Planning, Coding, and Review Strategy',
+    excerpt: 'A deep dive into the structured development workflow that eliminates 90% of bugs before they reach QA and scales across teams of 30+ developers.',
+    category: 'Methodology',
+    tags: ['Code Review', 'Best Practices', 'Team Leadership'],
+    coverImage: null,
+    publishedDate: '2025-11-20',
+    author: 'Santiago Arias',
+    readingTime: 7,
+  },
+];
+
+// Sample blocks for the first sample post (demonstrates the full reading experience)
+export const SAMPLE_BLOCKS: NotionBlock[] = [
+  {
+    id: 'b1',
+    type: 'paragraph',
+    has_children: false,
+    paragraph: {
+      rich_text: [
+        { type: 'text', plain_text: 'Over the past year, I\'ve completely transformed how I write software. What started as experimenting with GitHub Copilot evolved into a comprehensive ', annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }, href: null },
+        { type: 'text', plain_text: 'AI-first development methodology', annotations: { bold: true, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }, href: null },
+        { type: 'text', plain_text: ' that touches every phase of the software development lifecycle.', annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }, href: null },
+      ],
+      color: 'default',
+    },
+  },
+  {
+    id: 'b2',
+    type: 'heading_2',
+    has_children: false,
+    heading_2: {
+      rich_text: [{ type: 'text', plain_text: 'Why AI-First?', annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }, href: null }],
+      color: 'default',
+    },
+  },
+  {
+    id: 'b3',
+    type: 'paragraph',
+    has_children: false,
+    paragraph: {
+      rich_text: [
+        { type: 'text', plain_text: 'The term "AI-First" doesn\'t mean blindly delegating everything to an LLM. It means designing your workflow to ', annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }, href: null },
+        { type: 'text', plain_text: 'leverage AI strengths', annotations: { bold: false, italic: true, strikethrough: false, underline: false, code: false, color: 'default' }, href: null },
+        { type: 'text', plain_text: ' — pattern recognition, code generation, analysis at scale — while maintaining human judgment for architecture decisions, UX design, and critical business logic.', annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }, href: null },
+      ],
+      color: 'default',
+    },
+  },
+  {
+    id: 'b4',
+    type: 'callout',
+    has_children: false,
+    callout: {
+      rich_text: [{ type: 'text', plain_text: 'AI-first development is not about replacing developers. It\'s about amplifying what developers can accomplish in a given timeframe.', annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }, href: null }],
+      icon: { type: 'emoji', emoji: '💡' },
+      color: 'blue_background',
+    },
+  },
+  {
+    id: 'b5',
+    type: 'heading_2',
+    has_children: false,
+    heading_2: {
+      rich_text: [{ type: 'text', plain_text: 'The Three Pillars', annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }, href: null }],
+      color: 'default',
+    },
+  },
+  {
+    id: 'b6',
+    type: 'paragraph',
+    has_children: false,
+    paragraph: {
+      rich_text: [{ type: 'text', plain_text: 'My workflow is built on three pillars, each enhanced by AI tooling:', annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }, href: null }],
+      color: 'default',
+    },
+  },
+  {
+    id: 'b7',
+    type: 'heading_3',
+    has_children: false,
+    heading_3: {
+      rich_text: [{ type: 'text', plain_text: '1. AI-Assisted Planning', annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }, href: null }],
+      color: 'default',
+    },
+  },
+  {
+    id: 'b8',
+    type: 'paragraph',
+    has_children: false,
+    paragraph: {
+      rich_text: [{ type: 'text', plain_text: 'Before writing a single line of code, I use Claude to analyze requirements, identify edge cases, and draft an implementation plan. This catches architectural issues early when they\'re cheap to fix.', annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }, href: null }],
+      color: 'default',
+    },
+  },
+  {
+    id: 'b9',
+    type: 'code',
+    has_children: false,
+    code: {
+      rich_text: [{ type: 'text', plain_text: '# My typical planning prompt\n> claude "Analyze this feature request and create an implementation\n  plan. Consider: data model changes, API endpoints needed,\n  component hierarchy, edge cases, and testing strategy.\n  \n  Feature: User can customize their reading experience\n  with font selection, size adjustment, and theme modes."', annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }, href: null }],
+      language: 'bash',
+      caption: [{ type: 'text', plain_text: 'Using Claude Code for architectural planning', annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }, href: null }],
+    },
+  },
+  {
+    id: 'b10',
+    type: 'heading_3',
+    has_children: false,
+    heading_3: {
+      rich_text: [{ type: 'text', plain_text: '2. Pair Programming with AI', annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }, href: null }],
+      color: 'default',
+    },
+  },
+  {
+    id: 'b11',
+    type: 'paragraph',
+    has_children: false,
+    paragraph: {
+      rich_text: [
+        { type: 'text', plain_text: 'During implementation, I use AI as a pair programmer. The key insight is providing ', annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }, href: null },
+        { type: 'text', plain_text: 'rich context', annotations: { bold: true, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }, href: null },
+        { type: 'text', plain_text: ' — not just asking "write a function" but sharing the architectural vision, existing patterns, and constraints.', annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }, href: null },
+      ],
+      color: 'default',
+    },
+  },
+  {
+    id: 'b12',
+    type: 'bulleted_list_item',
+    has_children: false,
+    bulleted_list_item: {
+      rich_text: [
+        { type: 'text', plain_text: 'CLAUDE.md', annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: true, color: 'default' }, href: null },
+        { type: 'text', plain_text: ' files provide project-wide context automatically', annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }, href: null },
+      ],
+      color: 'default',
+    },
+  },
+  {
+    id: 'b13',
+    type: 'bulleted_list_item',
+    has_children: false,
+    bulleted_list_item: {
+      rich_text: [{ type: 'text', plain_text: 'Feature-based architecture means AI can focus on one module at a time', annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }, href: null }],
+      color: 'default',
+    },
+  },
+  {
+    id: 'b14',
+    type: 'bulleted_list_item',
+    has_children: false,
+    bulleted_list_item: {
+      rich_text: [{ type: 'text', plain_text: 'Barrel exports create clear boundaries that AI tools respect', annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }, href: null }],
+      color: 'default',
+    },
+  },
+  {
+    id: 'b15',
+    type: 'heading_3',
+    has_children: false,
+    heading_3: {
+      rich_text: [{ type: 'text', plain_text: '3. AI-Powered Code Review', annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }, href: null }],
+      color: 'default',
+    },
+  },
+  {
+    id: 'b16',
+    type: 'paragraph',
+    has_children: false,
+    paragraph: {
+      rich_text: [{ type: 'text', plain_text: 'Every PR goes through an AI review pass before human review. This catches common issues — missing error handling, inconsistent naming, potential performance problems — freeing human reviewers to focus on business logic and architectural concerns.', annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }, href: null }],
+      color: 'default',
+    },
+  },
+  {
+    id: 'b17',
+    type: 'quote',
+    has_children: false,
+    quote: {
+      rich_text: [{ type: 'text', plain_text: 'The best code reviews happen when the reviewer can focus on "is this the right approach?" instead of "did you forget a null check?"', annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }, href: null }],
+      color: 'default',
+    },
+  },
+  {
+    id: 'b18',
+    type: 'heading_2',
+    has_children: false,
+    heading_2: {
+      rich_text: [{ type: 'text', plain_text: 'Real-World Results', annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }, href: null }],
+      color: 'default',
+    },
+  },
+  {
+    id: 'b19',
+    type: 'paragraph',
+    has_children: false,
+    paragraph: {
+      rich_text: [{ type: 'text', plain_text: 'After 6 months of this workflow, the numbers speak for themselves:', annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }, href: null }],
+      color: 'default',
+    },
+  },
+  {
+    id: 'b20',
+    type: 'numbered_list_item',
+    has_children: false,
+    numbered_list_item: {
+      rich_text: [
+        { type: 'text', plain_text: '60% faster', annotations: { bold: true, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }, href: null },
+        { type: 'text', plain_text: ' feature delivery — from spec to production', annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }, href: null },
+      ],
+      color: 'default',
+    },
+  },
+  {
+    id: 'b21',
+    type: 'numbered_list_item',
+    has_children: false,
+    numbered_list_item: {
+      rich_text: [
+        { type: 'text', plain_text: '45% fewer bugs', annotations: { bold: true, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }, href: null },
+        { type: 'text', plain_text: ' reaching QA stage', annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }, href: null },
+      ],
+      color: 'default',
+    },
+  },
+  {
+    id: 'b22',
+    type: 'numbered_list_item',
+    has_children: false,
+    numbered_list_item: {
+      rich_text: [
+        { type: 'text', plain_text: '3x improvement', annotations: { bold: true, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }, href: null },
+        { type: 'text', plain_text: ' in code review turnaround time', annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }, href: null },
+      ],
+      color: 'default',
+    },
+  },
+  {
+    id: 'b23',
+    type: 'divider',
+    has_children: false,
+    divider: {},
+  },
+  {
+    id: 'b24',
+    type: 'heading_2',
+    has_children: false,
+    heading_2: {
+      rich_text: [{ type: 'text', plain_text: 'Tools in My Stack', annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }, href: null }],
+      color: 'default',
+    },
+  },
+  {
+    id: 'b25',
+    type: 'paragraph',
+    has_children: false,
+    paragraph: {
+      rich_text: [{ type: 'text', plain_text: 'Here\'s what my current AI-enhanced development environment looks like:', annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }, href: null }],
+      color: 'default',
+    },
+  },
+  {
+    id: 'b26',
+    type: 'code',
+    has_children: false,
+    code: {
+      rich_text: [{ type: 'text', plain_text: '// My AI Development Stack\nconst aiStack = {\n  planning:    "Claude Code /plan mode",\n  coding:      "Cursor + Claude Sonnet 4.5",\n  review:      "Claude Code /review-pr",\n  testing:     "AI-generated test cases",\n  docs:        "Auto-generated from code",\n  deployment:  "Vercel + GitHub Actions",\n};', annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }, href: null }],
+      language: 'typescript',
+      caption: [],
+    },
+  },
+  {
+    id: 'b27',
+    type: 'heading_2',
+    has_children: false,
+    heading_2: {
+      rich_text: [{ type: 'text', plain_text: 'Getting Started', annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }, href: null }],
+      color: 'default',
+    },
+  },
+  {
+    id: 'b28',
+    type: 'paragraph',
+    has_children: false,
+    paragraph: {
+      rich_text: [{ type: 'text', plain_text: 'If you want to adopt an AI-first workflow, start small. Pick one area — planning, coding, or review — and integrate AI there first. Once you see the benefits, expanding becomes natural.', annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }, href: null }],
+      color: 'default',
+    },
+  },
+  {
+    id: 'b29',
+    type: 'to_do',
+    has_children: false,
+    to_do: {
+      rich_text: [{ type: 'text', plain_text: 'Set up a CLAUDE.md file in your project', annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }, href: null }],
+      checked: true,
+      color: 'default',
+    },
+  },
+  {
+    id: 'b30',
+    type: 'to_do',
+    has_children: false,
+    to_do: {
+      rich_text: [{ type: 'text', plain_text: 'Try AI-assisted planning for your next feature', annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }, href: null }],
+      checked: false,
+      color: 'default',
+    },
+  },
+  {
+    id: 'b31',
+    type: 'to_do',
+    has_children: false,
+    to_do: {
+      rich_text: [{ type: 'text', plain_text: 'Measure your before/after velocity metrics', annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }, href: null }],
+      checked: false,
+      color: 'default',
+    },
+  },
+  {
+    id: 'b32',
+    type: 'paragraph',
+    has_children: false,
+    paragraph: {
+      rich_text: [
+        { type: 'text', plain_text: 'The future of software development is collaborative — humans and AI working together. The developers who master this collaboration will build better software, faster. And honestly? It makes the work ', annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }, href: null },
+        { type: 'text', plain_text: 'more fun', annotations: { bold: false, italic: true, strikethrough: false, underline: false, code: false, color: 'default' }, href: null },
+        { type: 'text', plain_text: '.', annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }, href: null },
+      ],
+      color: 'default',
+    },
+  },
+];

--- a/features/blog/index.ts
+++ b/features/blog/index.ts
@@ -1,0 +1,17 @@
+// Blog Feature - Barrel Export
+// Clean Architecture: Single entry point for the Blog feature
+
+// Components
+export { BlogList } from './components/BlogList';
+export { BlogCard } from './components/BlogCard';
+export { BlogReader } from './components/BlogReader';
+export { BlogSection } from './components/BlogSection';
+export { NotionBlockRenderer } from './components/NotionBlockRenderer';
+
+// Lib/Services
+export { getBlogPosts, getBlogPostBySlug } from './lib/notion';
+export { estimateReadingTime, extractHeadings, formatDate } from './lib/reading-utils';
+
+// Types & Constants
+export type { BlogPost, BlogPostWithContent, ReadingPreferences, NotionBlock } from './data/blog-types';
+export { SAMPLE_POSTS, DEFAULT_READING_PREFERENCES } from './data/blog-types';

--- a/features/blog/lib/notion.ts
+++ b/features/blog/lib/notion.ts
@@ -1,0 +1,203 @@
+// Blog Feature - Notion API Client
+// Clean Architecture: Data fetching isolated in lib layer
+
+import { Client } from '@notionhq/client';
+import { SAMPLE_POSTS, SAMPLE_BLOCKS } from '../data/blog-types';
+import { estimateReadingTime } from './reading-utils';
+import type { BlogPost, BlogPostWithContent, NotionBlock } from '../data/blog-types';
+
+// Check if Notion is configured
+const isNotionConfigured = !!(process.env.NOTION_TOKEN && process.env.NOTION_DATABASE_ID);
+
+const notion = isNotionConfigured
+  ? new Client({ auth: process.env.NOTION_TOKEN })
+  : null;
+
+const DATABASE_ID = process.env.NOTION_DATABASE_ID || '';
+
+/**
+ * Maps a Notion page object to our BlogPost type
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function pageToPost(page: any): BlogPost {
+  const props = page.properties;
+
+  return {
+    id: page.id,
+    slug: props.Slug?.rich_text?.[0]?.plain_text || '',
+    title: props.Name?.title?.[0]?.plain_text || '',
+    excerpt: props.Excerpt?.rich_text?.[0]?.plain_text || '',
+    category: props.Category?.select?.name || '',
+    tags: props.Tags?.multi_select?.map((t: { name: string }) => t.name) || [],
+    coverImage:
+      page.cover?.external?.url ||
+      page.cover?.file?.url ||
+      props.Cover?.files?.[0]?.external?.url ||
+      props.Cover?.files?.[0]?.file?.url ||
+      null,
+    publishedDate: props.Date?.date?.start || '',
+    author: props.Author?.rich_text?.[0]?.plain_text || 'Santiago Arias',
+  };
+}
+
+/**
+ * Fetches all published blog posts from Notion
+ * Falls back to sample data when Notion is not configured
+ */
+export async function getBlogPosts(): Promise<BlogPost[]> {
+  if (!isNotionConfigured || !notion) {
+    return SAMPLE_POSTS;
+  }
+
+  try {
+    // Notion SDK v5: databases.query → dataSources.query
+    const response = await notion.dataSources.query({
+      data_source_id: DATABASE_ID,
+      filter: {
+        property: 'Published',
+        checkbox: { equals: true },
+      },
+      sorts: [
+        { property: 'Date', direction: 'descending' },
+      ],
+    });
+
+    const posts = response.results.map(pageToPost);
+
+    // Fetch reading time for each post
+    const postsWithReadingTime = await Promise.all(
+      posts.map(async (post) => {
+        try {
+          const blocks = await getBlockChildren(post.id);
+          return { ...post, readingTime: estimateReadingTime(blocks) };
+        } catch {
+          return { ...post, readingTime: 5 };
+        }
+      })
+    );
+
+    return postsWithReadingTime;
+  } catch (error) {
+    console.error('Error fetching blog posts from Notion:', error);
+    return SAMPLE_POSTS;
+  }
+}
+
+/**
+ * Fetches a single blog post by slug
+ */
+export async function getBlogPostBySlug(slug: string): Promise<BlogPostWithContent | null> {
+  if (!isNotionConfigured || !notion) {
+    const samplePost = SAMPLE_POSTS.find((p) => p.slug === slug);
+    if (!samplePost) return null;
+
+    const blocks = slug === 'building-ai-first-development-workflow' ? SAMPLE_BLOCKS : generateGenericBlocks(samplePost.title, samplePost.excerpt);
+
+    return {
+      ...samplePost,
+      readingTime: estimateReadingTime(blocks),
+      blocks,
+    };
+  }
+
+  try {
+    const response = await notion.dataSources.query({
+      data_source_id: DATABASE_ID,
+      filter: {
+        and: [
+          { property: 'Slug', rich_text: { equals: slug } },
+          { property: 'Published', checkbox: { equals: true } },
+        ],
+      },
+    });
+
+    if (response.results.length === 0) return null;
+
+    const page = response.results[0];
+    const post = pageToPost(page);
+    const blocks = await getBlockChildren(page.id);
+
+    return {
+      ...post,
+      readingTime: estimateReadingTime(blocks),
+      blocks,
+    };
+  } catch (error) {
+    console.error('Error fetching blog post:', error);
+    return null;
+  }
+}
+
+/**
+ * Recursively fetches all blocks (content) for a Notion page
+ */
+async function getBlockChildren(blockId: string): Promise<NotionBlock[]> {
+  if (!notion) return [];
+
+  const blocks: NotionBlock[] = [];
+  let cursor: string | undefined;
+
+  do {
+    const response = await notion.blocks.children.list({
+      block_id: blockId,
+      start_cursor: cursor,
+    });
+
+    for (const block of response.results) {
+      const b = block as unknown as NotionBlock;
+      if (b.has_children && b.type !== 'child_page') {
+        b.children = await getBlockChildren(b.id);
+      }
+      blocks.push(b);
+    }
+
+    cursor = response.has_more ? (response.next_cursor ?? undefined) : undefined;
+  } while (cursor);
+
+  return blocks;
+}
+
+/**
+ * Generates generic sample blocks for posts without custom content
+ */
+function generateGenericBlocks(title: string, excerpt: string): NotionBlock[] {
+  return [
+    {
+      id: 'gen-1',
+      type: 'paragraph',
+      has_children: false,
+      paragraph: {
+        rich_text: [{ type: 'text', plain_text: excerpt, annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }, href: null }],
+        color: 'default',
+      },
+    },
+    {
+      id: 'gen-2',
+      type: 'callout',
+      has_children: false,
+      callout: {
+        rich_text: [{ type: 'text', plain_text: `This is a preview of "${title}". Connect your Notion database to see the full content.`, annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }, href: null }],
+        icon: { type: 'emoji', emoji: '📝' },
+        color: 'gray_background',
+      },
+    },
+    {
+      id: 'gen-3',
+      type: 'heading_2',
+      has_children: false,
+      heading_2: {
+        rich_text: [{ type: 'text', plain_text: 'Coming Soon', annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }, href: null }],
+        color: 'default',
+      },
+    },
+    {
+      id: 'gen-4',
+      type: 'paragraph',
+      has_children: false,
+      paragraph: {
+        rich_text: [{ type: 'text', plain_text: 'The full article will be available once the Notion CMS is connected. In the meantime, you can explore the reading controls above to customize your reading experience.', annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }, href: null }],
+        color: 'default',
+      },
+    },
+  ];
+}

--- a/features/blog/lib/reading-utils.ts
+++ b/features/blog/lib/reading-utils.ts
@@ -1,0 +1,60 @@
+// Blog Feature - Reading Utilities
+
+import type { NotionBlock } from '../data/blog-types';
+
+/**
+ * Extracts plain text from a Notion block's rich_text array
+ */
+export function extractTextFromBlock(block: NotionBlock): string {
+  const content = block[block.type];
+  if (!content?.rich_text) return '';
+  return content.rich_text
+    .map((t: { plain_text: string }) => t.plain_text)
+    .join('');
+}
+
+/**
+ * Estimates reading time based on word count (225 wpm average)
+ */
+export function estimateReadingTime(blocks: NotionBlock[]): number {
+  let wordCount = 0;
+
+  for (const block of blocks) {
+    const text = extractTextFromBlock(block);
+    wordCount += text.split(/\s+/).filter(Boolean).length;
+
+    if (block.children) {
+      wordCount += blocks.reduce((acc, b) => {
+        const t = extractTextFromBlock(b);
+        return acc + t.split(/\s+/).filter(Boolean).length;
+      }, 0);
+    }
+  }
+
+  return Math.max(1, Math.ceil(wordCount / 225));
+}
+
+/**
+ * Extracts headings from blocks for Table of Contents
+ */
+export function extractHeadings(blocks: NotionBlock[]): { id: string; text: string; level: number }[] {
+  return blocks
+    .filter((block) => ['heading_1', 'heading_2', 'heading_3'].includes(block.type))
+    .map((block) => ({
+      id: block.id,
+      text: extractTextFromBlock(block),
+      level: parseInt(block.type.split('_')[1]),
+    }));
+}
+
+/**
+ * Format a date string for display
+ */
+export function formatDate(dateString: string): string {
+  const date = new Date(dateString);
+  return date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@base-ui-components/react": "^1.0.0-alpha.1",
         "@libsql/client": "^0.17.0",
         "@midudev/tailwind-animations": "0.2.0",
+        "@notionhq/client": "^5.9.0",
         "@openrouter/ai-sdk-provider": "^2.1.1",
         "@radix-ui/react-avatar": "^1.0.4",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -1184,6 +1185,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@notionhq/client": {
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/@notionhq/client/-/client-5.9.0.tgz",
+      "integrity": "sha512-TvAVMfwtVv61hsPrRfB9ehgzSjX6DaAi1ZRAnpg8xFjzaXhzhEfbO0PhBRm3ecSv1azDuO2kBuyQHh2/z7G4YQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@octokit/auth-token": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@base-ui-components/react": "^1.0.0-alpha.1",
     "@libsql/client": "^0.17.0",
     "@midudev/tailwind-animations": "0.2.0",
+    "@notionhq/client": "^5.9.0",
     "@openrouter/ai-sdk-provider": "^2.1.1",
     "@radix-ui/react-avatar": "^1.0.4",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -5,6 +5,8 @@ const config = {
   content: [
     './pages/**/*.{ts,tsx}',
     './components/**/*.{ts,tsx}',
+    './features/**/*.{ts,tsx}',
+    './shared/**/*.{ts,tsx}',
     './app/**/*.{ts,tsx}',
     './src/**/*.{ts,tsx}',
 	],


### PR DESCRIPTION
- Add blog feature module following clean architecture (features/blog/)
- Integrate Notion API (@notionhq/client v5) as CMS with ISR revalidation
- Build ebook-style reading experience with customizable preferences:
  - Font selection (Georgia, Sans, Charter, Mono)
  - Font size (14-24px) and line height (1.4-2.2) controls
  - Content width (narrow/medium/wide)
  - 4 reading themes (Light, Dark, Sepia, Paper)
  - Reading progress bar and auto-generated Table of Contents
  - Preferences persisted in localStorage
- Create NotionBlockRenderer supporting all common Notion block types
- Add blog listing page with category filters and Framer Motion animations
- Add BlogSection to homepage with latest posts preview
- Include sample data fallback when Notion is not configured
- Add features/ and shared/ paths to Tailwind content config

https://claude.ai/code/session_019dhAyrKQeo2Z5WMdyP2G44